### PR TITLE
Show metric's name and type if exists

### DIFF
--- a/components/Explorer.tsx
+++ b/components/Explorer.tsx
@@ -10,11 +10,14 @@ import {
   majorScale,
   Pane,
   Pill,
+  Text,
 } from "evergreen-ui";
 
 import type DoublyLinkedMeterTree from "../types/DoublyLinkedMeterTree";
+import type Meter from "../types/Meter";
 
 import Breadcrumbs from "./Breadcrumbs";
+import MetricTypeBadge from "./MetricTypeBadge";
 
 interface ExplorerProps {
   root: DoublyLinkedMeterTree;
@@ -95,19 +98,38 @@ function Child({ child, onClick }: ChildProps) {
     <Card
       border="default"
       display="flex"
+      flexDirection="column"
       margin={majorScale(1)}
       padding={majorScale(2)}
     >
-      <Pane alignItems="center" display="flex" flex={1} flexDirection="row">
-        <Heading marginRight={majorScale(1)}>{child.name}</Heading>
-        <Pill>{child.count}</Pill>
-      </Pane>
-      {Object.keys(child.children).length > 0 && (
-        <Pane>
-          <IconButton icon={ChevronRightIcon} onClick={onClick} />
+      <Pane alignItems="center" display="flex">
+        <Pane flex={1}>
+          <Pane alignItems="center" display="flex">
+            <Heading marginRight={majorScale(1)}>{child.name}</Heading>
+            <Pill>{child.count}</Pill>
+          </Pane>
         </Pane>
-      )}
+        {Object.keys(child.children).length > 0 && (
+          <Pane>
+            <IconButton icon={ChevronRightIcon} onClick={onClick} />
+          </Pane>
+        )}
+      </Pane>
+      {child.meter && <MetricInformation metric={child.meter} />}
     </Card>
+  );
+}
+
+interface MetricInformationProps {
+  metric: Meter;
+}
+
+function MetricInformation({ metric }: MetricInformationProps) {
+  return (
+    <Pane alignItems="center" display="flex" flexDirection="row">
+      <Text marginRight={majorScale(1)}>{metric.name}</Text>
+      <MetricTypeBadge type={metric.type} />
+    </Pane>
   );
 }
 

--- a/components/MetricTypeBadge.tsx
+++ b/components/MetricTypeBadge.tsx
@@ -1,0 +1,27 @@
+import { Badge } from "evergreen-ui";
+
+import MetricType from "../types/MetricType";
+
+interface MetricTypeBadgeProps {
+  type: MetricType;
+}
+
+export default function MetricTypeBadge({ type }: MetricTypeBadgeProps) {
+  return <Badge color={colorOf(type)}>{type}</Badge>;
+}
+
+type Color = "neutral" | "blue" | "orange" | "green" | "purple";
+
+function colorOf(type: MetricType): Color {
+  switch (type) {
+    case MetricType.Counter:
+      return "green";
+    case MetricType.Gauge:
+      return "blue";
+    case MetricType.Histogram:
+      return "orange";
+    case MetricType.Summary:
+      return "purple";
+  }
+  return "neutral";
+}

--- a/libs/parsePrometheus.ts
+++ b/libs/parsePrometheus.ts
@@ -1,6 +1,7 @@
 import produce from "immer";
 
 import type Meter from "../types/Meter";
+import MetricType from "../types/MetricType";
 
 export default function parsePrometheus(content: string): {
   [name: string]: Meter;
@@ -21,7 +22,7 @@ export default function parsePrometheus(content: string): {
           meters[name] = {
             name: name,
             description: description,
-            type: "",
+            type: MetricType.Unknown,
             count: 0,
           };
         }
@@ -47,7 +48,12 @@ export default function parsePrometheus(content: string): {
             draft.count += 1;
           });
         } else {
-          meters[name] = { name: name, description: "", type: "", count: 1 };
+          meters[name] = {
+            name: name,
+            description: "",
+            type: MetricType.Unknown,
+            count: 1,
+          };
         }
       }
     });
@@ -62,11 +68,15 @@ function parseHelpText(line: string): { name: string; description: string } {
   return { name, description };
 }
 
-function parseTypeInformation(line: string): { name: string; type: string } {
+function parseTypeInformation(line: string): {
+  name: string;
+  type: MetricType;
+} {
   const remaining = line.substring(7); // `# TYPE` + trailing whiespace.
 
   const name = remaining.substring(0, remaining.indexOf(" "));
-  const type = remaining.substring(name.length + 1);
+  const typeString = remaining.substring(name.length + 1).toLowerCase();
+  const type = typeString as MetricType;
   return { name, type };
 }
 

--- a/types/Meter.ts
+++ b/types/Meter.ts
@@ -1,6 +1,8 @@
+import type MetricType from "./MetricType";
+
 export default interface Meter {
   readonly name: string;
   readonly description: string;
-  readonly type: string;
+  readonly type: MetricType;
   readonly count: number;
 }

--- a/types/MetricType.ts
+++ b/types/MetricType.ts
@@ -1,0 +1,9 @@
+enum MetricType {
+  Counter = "counter",
+  Gauge = "gauge",
+  Histogram = "histogram",
+  Summary = "summary",
+  Unknown = "",
+}
+
+export default MetricType;


### PR DESCRIPTION
`Explorer` only shows current name of metric tree. It would be useful to see metric's full name and type if a node has metric.

Add `MetricType` enum that has types described in the [Prometheus documentation](https://prometheus.io/docs/concepts/metric_types/).

Add `MetricInformation` component which shows the given metric's name and type. Users easy distinguish each types because they have different colors. The new `MetricTypeBadge` handles.