### PR TITLE
Add target URL's hostname as root node of breadcrumbs

### DIFF
--- a/components/Explorer.tsx
+++ b/components/Explorer.tsx
@@ -40,7 +40,6 @@ export default function Explorer({ root }: ExplorerProps) {
     <Pane display="flex" flexDirection="column">
       <Breadcrumbs>
         {ancestors
-          .filter((ancestor) => ancestor.parent)
           .reverse()
           .map((ancestor, index) => (
             <Button

--- a/pages/Main.tsx
+++ b/pages/Main.tsx
@@ -20,9 +20,10 @@ export default function Main({ url }: MainProps) {
 
   useEffect(() => {
     const fetchPrometheus = async () => {
-      const response = await fetch(`/api/prometheus?url=${url}`);
+      const validUrl = new URL(url);
+      const response = await fetch(`/api/prometheus?url=${validUrl.href}`);
       const newTree: MeterTree = await response.json();
-      setTree(doubleLink("", newTree));
+      setTree(doubleLink(validUrl.hostname, newTree));
     };
     fetchPrometheus();
   }, [url]);


### PR DESCRIPTION
Sets the target URL's hostname as the name of the root node of the tree. And now the explorer always shows breadcrumbs.

Close #7